### PR TITLE
feat: adding getImage support

### DIFF
--- a/eufy-security/01-eufy-security.js
+++ b/eufy-security/01-eufy-security.js
@@ -242,6 +242,9 @@ module.exports = function (RED) {
             case EUFY_SECURITY_COMMANDS.GET_DEVICES:
               this.sendCommandResult(command, await this.driver.getDevices());
               break;
+            case EUFY_SECURITY_COMMANDS.GET_IMAGE:
+              this.sendCommandResult(command,(await this.driver.api.getImage(deviceSN,value)).toString('base64'));
+              break;
             default:
               throw new Error("Unknown command");
           }

--- a/eufy-security/constants.js
+++ b/eufy-security/constants.js
@@ -19,6 +19,7 @@ const EUFY_SECURITY_COMMANDS = {
   GET_STATION_DEVICE: 'get station device',
   GET_DEVICE: 'get device',
   GET_DEVICES: 'get devices',
+  GET_IMAGE: 'get image',
 };
 
 module.exports = {


### PR DESCRIPTION
I'm trying to get the actual image from an event into a flow. I initially just added it as extra logic in sendPayload to check for pic_url and try to get it. but, that delays the initial message transmission. the second solution was to send it as a follow up second message win sendPayload, but then you have extra messages. this, the third solution, keeps it more in line with existing behaviors, i think, but i just started looking at node-red last week so feel free to suggest other paths!